### PR TITLE
feat!: rm yarn, node setup

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,6 +16,9 @@ jobs:
     steps:
 
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"      
 
       - name: Create yaml file
         run: |
@@ -91,6 +94,9 @@ jobs:
     steps:
 
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"      
 
       - run: echo -e "$TEMP_KUBECONFIG" > /tmp/kubeconfig
         shell: bash
@@ -157,6 +163,9 @@ jobs:
     steps:
 
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"      
 
       - name: Create yaml file
         run: |

--- a/README.md
+++ b/README.md
@@ -90,7 +90,10 @@ jobs:
     
     steps:
       - uses: actions/checkout@v4
-        
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+
       - name: Create starship devnet for osmos and wasm
         uses: hyperweb-io/starship-action@1.0.0
         with:

--- a/action.yaml
+++ b/action.yaml
@@ -42,26 +42,6 @@ runs:
   using: composite
   steps:
 
-    - name: Create yarn.lock and package.json file if not exists
-      if: inputs.cli-version != '0.0.0'  # Skip if cli-version is 0.0.0, expected to be used for local testing
-      run: |
-        if [ ! -f $GITHUB_WORKSPACE/yarn.lock ]; then
-          echo 'Creating temporary yarn.lock file'
-          echo '' > $GITHUB_WORKSPACE/yarn.lock
-        fi
-        if [ ! -f $GITHUB_WORKSPACE/package.json ]; then
-          echo 'Creating temporary package.json file'
-          echo '{}' > $GITHUB_WORKSPACE/package.json
-        fi
-      shell: bash
-
-    - name: Setup Node.js
-      uses: actions/setup-node@v4
-      if: inputs.cli-version != '0.0.0'  # Skip if cli-version is 0.0.0, expected to be used for local testing
-      with:
-        node-version: "20.x"
-        cache: "yarn"
-
     - name: Setup helm
       uses: azure/setup-helm@v3
       with:
@@ -114,7 +94,7 @@ runs:
     - name: Setup starshipjs client
       if: inputs.cli-version != '0.0.0'  # Skip if cli-version is 0.0.0, expected to be used for local testing
       run: |
-        yarn global add @starship-ci/cli@${{ inputs.cli-version }}
+        npm install -g @starship-ci/cli@${{ inputs.cli-version }}
       shell: bash
 
     - name: Verify starship cli


### PR DESCRIPTION
## Description

The current `starship-action` internally uses `actions/setup-node` and yarn to install `@starship-ci/cli`. This forces a specific Node.js version and package manager (yarn), which may conflict with user project configurations.

Since `@starship-ci/cli` can be executed via `npx`, this PR removes the Node.js/yarn setup and relies on the runner's pre-installed environment instead.

## Changes

- Removes `actions/setup-node` and yarn installation steps
- Updates docs and tests